### PR TITLE
Fix the openal-soft build with lld.

### DIFF
--- a/audio/openal-soft/files/patch-CMakeLists.txt
+++ b/audio/openal-soft/files/patch-CMakeLists.txt
@@ -1,6 +1,15 @@
---- CMakeLists.txt.orig	2016-01-25 03:12:39 UTC
-+++ CMakeLists.txt
-@@ -582,10 +582,6 @@ int main()
+--- CMakeLists.txt.orig	2016-01-25 03:12:39.000000000 +0000
++++ CMakeLists.txt	2017-01-11 14:40:47.389333000 +0000
+@@ -4,6 +4,8 @@
+ 
+ PROJECT(OpenAL)
+ 
++SET(CMAKE_POSITION_INDEPENDENT_CODE ON)
++
+ IF(COMMAND CMAKE_POLICY)
+     CMAKE_POLICY(SET CMP0003 NEW)
+     CMAKE_POLICY(SET CMP0005 NEW)
+@@ -582,10 +584,6 @@
  
      CHECK_SYMBOL_EXISTS(pthread_mutex_timedlock pthread.h HAVE_PTHREAD_MUTEX_TIMEDLOCK)
  
@@ -11,7 +20,7 @@
  ENDIF()
  
  # Check for a 64-bit type
-@@ -1184,7 +1180,7 @@ IF(ALSOFT_INSTALL)
+@@ -1184,7 +1182,7 @@
              DESTINATION include/AL
      )
      INSTALL(FILES "${OpenAL_BINARY_DIR}/openal.pc"


### PR DESCRIPTION
The problem was an auxiliary program requiring a protected symbol to
be preempted.

The easy fix for now is to just use -fPIE which has the side effect of
using GOTs and PLTs for accessing external symbols.