### PR TITLE
Fix link error.

### DIFF
--- a/audio/freealut/Makefile
+++ b/audio/freealut/Makefile
@@ -12,7 +12,7 @@ MAINTAINER=	oliver@FreeBSD.org
 COMMENT=	The OpenAL Utility Toolkit
 
 GNU_CONFIGURE=	yes
-CPPFLAGS+=	-I${LOCALBASE}/include
+CPPFLAGS+=	-I${LOCALBASE}/include -fPIC
 LDFLAGS+=	-L${LOCALBASE}/lib
 USES=		gmake libtool openal:al pathfix pkgconfig
 USE_LDCONFIG=	yes


### PR DESCRIPTION
This packages has example programs that would try to preempt a protected symbol.

This is a hack, but adding USE_AUTOTOOLS fails and is just not worth the pain for now.