### PR TITLE
Fix the ARJ build.

### DIFF
--- a/archivers/arj/files/patch-gnu_configure.in
+++ b/archivers/arj/files/patch-gnu_configure.in
@@ -1,0 +1,10 @@
+--- gnu/configure.in.orig	2017-01-20 23:17:27.771296000 +0000
++++ gnu/configure.in	2017-01-20 23:17:31.994024000 +0000
+@@ -60,7 +60,6 @@
+ *bsd*)
+ 	AC_DEFINE(ELF_EXECUTABLES)
+         DLL_FLAGS="-shared -export-dynamic"
+-        LD_STRIP="gnu/stripgcc.lnk"
+ 	;;
+ interix3*)
+ 	# not ELF


### PR DESCRIPTION
The script consists of just

SECTIONS
{
 /DISCARD/ : { *(.comment) *(.note) *(.stab) *(.stabstr) }
}

and is passed to ld without --script. The BFD behavior is to somehow
combine that with the default script. For exmaple, there is a default
start address and PT_LOAD areas are magically aligned.

I don't think that is something we can support in any sane way in lld.