### PR TITLE
Fix the libxine build.

### DIFF
--- a/multimedia/libxine/Makefile
+++ b/multimedia/libxine/Makefile
@@ -116,6 +116,8 @@ LIBBLURAY_CONFIGURE_ENABLE=	bluray
 
 .include <bsd.port.options.mk>
 
+CFLAGS+= -fPIC
+
 .if ${ARCH} == "i386"
 CFLAGS+=	-fomit-frame-pointer
 .endif


### PR DESCRIPTION
This builds both a library and a program that uses it. The library has
protected symbols and the program tries to access them directly.

This is just the brute force fix to get it to build for now.