### PR TITLE
Temporary fix for the xine build.

### DIFF
--- a/multimedia/xine/Makefile
+++ b/multimedia/xine/Makefile
@@ -27,6 +27,7 @@ INSTALLS_ICONS=	yes
 
 CPPFLAGS+=	-I${LOCALBASE}/include
 LDFLAGS+=	-L${LOCALBASE}/lib
+CFLAGS+=        -fPIC
 
 DOCSDIR=	${PREFIX}/share/doc/xine-ui
 


### PR DESCRIPTION
It was trying to create copy relocations of protected symbols.