### PR TITLE
Fix postgresql94-contrib build.

### DIFF
--- a/databases/postgresql94-server/files/patch-contrib_spi_Makefile
+++ b/databases/postgresql94-server/files/patch-contrib_spi_Makefile
@@ -1,0 +1,11 @@
+--- contrib/spi/Makefile.orig	2017-02-07 18:45:42.537013000 +0000
++++ contrib/spi/Makefile	2017-02-07 18:45:55.036366000 +0000
+@@ -16,7 +16,7 @@
+ # comment out if you want a quieter refint package for other uses
+ PG_CPPFLAGS = -DREFINT_VERBOSE
+ 
+-LDFLAGS_SL += -L$(top_builddir)/src/port -lpgport
++LDFLAGS_SL += -L$(top_builddir)/src/port
+ 
+ ifdef USE_PGXS
+ PG_CONFIG = pg_config


### PR DESCRIPTION
It was passing a -l pointing to a static library when building a
.so. It works with bfd just because the command line looks like

-lfoo use_symbol_in_foo.o

and bfd never looks back in the command line.