### PR TITLE
Fix bash-static build.

### DIFF
--- a/shells/bash/Makefile
+++ b/shells/bash/Makefile
@@ -31,6 +31,7 @@ USES=			bison cpe iconv makeinfo pathfix
 GNU_CONFIGURE=		yes
 OPTIONS_SUB=		yes
 CPE_VENDOR=		gnu
+USE_AUTOTOOLS=          autoconf
 
 COLONBREAKSWORDS_EXTRA_PATCHES=	${PATCHDIR}/extrapatch-colonbreakswords
 

--- a/shells/bash/files/patch-configure.ac
+++ b/shells/bash/files/patch-configure.ac
@@ -1,0 +1,11 @@
+--- configure.ac.old	2017-02-09 17:24:41.296148000 +0000
++++ configure.ac	2017-02-09 17:24:48.760420000 +0000
+@@ -826,8 +826,6 @@
+ BASH_CHECK_DECL(strtoull)
+ BASH_CHECK_DECL(strtoumax)
+ 
+-AC_FUNC_MKTIME
+-
+ dnl
+ dnl Checks for lib/intl and related code (uses some of the output from
+ dnl AM_GNU_GETTEXT)


### PR DESCRIPTION
This is an annoying one.

Configure has

AC_FUNC_MKTIME

which expands to a test of mktime that fails with the freebsd
implementation. Given that, bash compiles a mktime.o file that defines
just mktime and uses localtime. That goes in a .a file that is before
libc.

The freebsd libc defines mktime in localtime.o, which also defines
localtime among other functions.

When lld sees an undefined reference to mktime from libc, it uses the
bash provided one and then tries to find a definition of localtime. It
is found on libc's localtime.o, but now we have a duplicated error.

The reason it works with bfd is that bash doesn't use mktime directly
and the undefined reference from libc is resolved to the libc
implementation. It would also fail to link if bash itself directly
used mktime.

Freebsd should probably consider fixing mktime to pass AC_FUNC_MKTIME
(or fix AC_FUNC_MKTIME). It should probably also split mktime into its
own file so that it is possible to replace just that function.